### PR TITLE
Added scss-lint tasks

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,244 @@
+# Linter documentation:
+#  https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md
+
+scss_files: "**/*.scss"
+plugin_directories: ['.scss-linters']
+
+exclude:
+  - 'src/static/scss/vendor/*.scss'
+
+# List of gem names to load custom linters from (make sure they are already
+# installed)
+plugin_gems: []
+
+linters:
+  BangFormat:
+    enabled: true
+    space_before_bang: true
+    space_after_bang: false
+
+  BemDepth:
+    enabled: false
+    max_elements: 1
+
+  BorderZero:
+    enabled: true
+    convention: zero # or `none`
+
+  ColorKeyword:
+    enabled: true
+
+  ColorVariable:
+    enabled: true
+
+  Comment:
+    enabled: true
+
+  DebugStatement:
+    enabled: true
+
+  DeclarationOrder:
+    enabled: true
+
+  DisableLinterReason:
+    enabled: false
+
+  DuplicateProperty:
+    enabled: true
+
+  ElsePlacement:
+    enabled: true
+    style: same_line # or 'new_line'
+
+  EmptyLineBetweenBlocks:
+    enabled: true
+    ignore_single_line_blocks: true
+
+  EmptyRule:
+    enabled: true
+
+  ExtendDirective:
+    enabled: false
+
+  FinalNewline:
+    enabled: true
+    present: true
+
+  HexLength:
+    enabled: true
+    style: short # or 'long'
+
+  HexNotation:
+    enabled: true
+    style: lowercase # or 'uppercase'
+
+  HexValidation:
+    enabled: true
+
+  IdSelector:
+    enabled: true
+
+  ImportantRule:
+    enabled: true
+
+  ImportPath:
+    enabled: true
+    leading_underscore: false
+    filename_extension: false
+
+  Indentation:
+    enabled: true
+    allow_non_nested_indentation: false
+    character: space # or 'tab'
+    width: 4
+
+  LeadingZero:
+    enabled: true
+    style: exclude_zero # or 'include_zero'
+
+  MergeableSelector:
+    enabled: true
+    force_nesting: true
+
+  NameFormat:
+    enabled: true
+    allow_leading_underscore: true
+    convention: hyphenated_lowercase # or 'camel_case', or 'snake_case', or a regex pattern
+
+  NestingDepth:
+    enabled: true
+    max_depth: 3
+    ignore_parent_selectors: false
+
+  PlaceholderInExtend:
+    enabled: true
+
+  PropertyCount:
+    enabled: false
+    include_nested: false
+    max_properties: 10
+
+  PropertySortOrder:
+    enabled: false
+    ignore_unspecified: false
+    min_properties: 2
+    separate_groups: false
+
+  PropertySpelling:
+    enabled: true
+    extra_properties: []
+
+  PropertyUnits:
+    enabled: true
+    global: [
+      'em', 'rem',                     # Font-relative lengths
+      'px',                            # Absolute lengths
+      'vh', 'vw', 'vmin', 'vmax',      # Viewport-percentage lengths
+      'deg', 'grad', 'rad', 'turn',    # Angle
+      'ms', 's',                       # Duration
+      'Hz', 'kHz',                     # Frequency
+      'dpi', 'dpcm', 'dppx',           # Resolution
+      '%']                             # Other
+    properties: {
+      line-height: []                  # No units allowed
+    }
+
+  QualifyingElement:
+    enabled: true
+    allow_element_with_attribute: false
+    allow_element_with_class: false
+    allow_element_with_id: false
+
+  SelectorDepth:
+    enabled: true
+    max_depth: 3
+
+  SelectorFormat:
+    enabled: true
+    convention: hyphenated_lowercase # or 'strict_BEM', or 'hyphenated_BEM', or 'snake_case', or 'camel_case', or a regex pattern
+
+  Shorthand:
+    enabled: true
+    allowed_shorthands: [1, 2, 3]
+
+  SingleLinePerProperty:
+    enabled: true
+    allow_single_line_rule_sets: true
+
+  SingleLinePerSelector:
+    enabled: true
+
+  SpaceAfterComma:
+    enabled: true
+    style: one_space # or 'no_space', or 'at_least_one_space'
+
+  SpaceAfterPropertyColon:
+    enabled: true
+    style: one_space # or 'no_space', or 'at_least_one_space', or 'aligned'
+
+  SpaceAfterPropertyName:
+    enabled: true
+
+  SpaceAfterVariableName:
+    enabled: true
+
+  SpaceAroundOperator:
+    enabled: true
+    style: one_space # or 'no_space'
+
+  SpaceBeforeBrace:
+    enabled: true
+    style: space # or 'new_line'
+    allow_single_line_padding: true
+
+  SpaceBetweenParens:
+    enabled: true
+    spaces: 0
+
+  StringQuotes:
+    enabled: true
+    style: single_quotes # or double_quotes
+
+  TrailingSemicolon:
+    enabled: true
+
+  TrailingWhitespace:
+    enabled: true
+
+  TrailingZero:
+    enabled: false
+
+  TransitionAll:
+    enabled: true
+
+  UnnecessaryMantissa:
+    enabled: true
+
+  UnnecessaryParentReference:
+    enabled: true
+
+  UrlFormat:
+    enabled: true
+
+  UrlQuotes:
+    enabled: true
+
+  VariableForProperty:
+    enabled: true
+    properties: [
+        font-size,
+        font-family,
+        line-height
+    ]
+
+  VendorPrefix:
+    enabled: true
+    identifier_list: base
+    additional_identifiers: []
+    excluded_identifiers: []
+
+  ZeroUnit:
+    enabled: true
+
+  Compass::*:
+    enabled: false

--- a/config.js
+++ b/config.js
@@ -19,7 +19,7 @@ module.exports = {
             globStaticAll:  base.src + '/static/scss/**/*.scss',
             globComponents: base.src + '/components/**/*.scss',
             dirDist:        base.dist + '/static/css',
-            sassdocsDist:   base.dist + 'docs/sassdoc'
+            sassdocsDist:   base.dist + '/docs/sassdoc'
         },
         html: {
             globTemplates:  base.src + '/templates/**/*.html',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,10 +18,11 @@ gulp.task('html-watch', ['html-compile'], tasksHTML.watch);
 gulp.task('img-optimize', tasksImages.optimize);
 gulp.task('img-watch', ['img-optimize'], tasksImages.watch);
 
-// Sass & Autoprefixer to CSS compiler
+// SASS & CSS Tasks
 gulp.task('css-compile', tasksCSS.compile);
 gulp.task('css-watch', ['css-compile'], tasksCSS.watch);
 gulp.task('css-sassdoc', tasksCSS.sassdoc);
+gulp.task('scss-lint', tasksCSS.scsslint);
 
 // JavaScript transpiler
 gulp.task('js-transpile', tasksJS.transpile);
@@ -31,4 +32,4 @@ gulp.task('js-watch', ['js-transpile'], tasksJS.watch);
 // Group-tasks
 gulp.task('dev', ['browsersync', 'html-watch', 'img-watch', 'css-watch', 'js-watch']);
 gulp.task('dist', [/*'clean', */'html-compile', 'img-optimize', 'css-compile', 'js-transpile']);
-gulp.task('test', ['js-test']);
+gulp.task('test', ['js-test', 'scss-lint']);

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
         "url": "https://github.com/mirabeau-nl/frontend-bootstrap.git"
     },
     "scripts": {
+        "postinstall":  "(scss-lint -v || gem install scss-lint -v 0.41.0)",
         "start": "node_modules/gulp/bin/gulp.js dev"
     },
     "contributors": [
         "Bran van der Meer <branmovic@gmail.com> (http://bran.name/)",
         "Rik Schennink <rikschennink@gmail.com> (http://rikschennink.nl/)",
-        "Niek Bosch <nbosch@mirabeau.nl> (http://rikschennink.nl/)",
+        "Niek Bosch <nbosch@mirabeau.nl> (http://www.mirabeau.nl/)",
         "Eric Weerstra <eweerstra@mirabeau.nl> (http://www.mirabeau.nl/)",
         "Arno Wolkers <awolkers@mirabeau.nl> (http://www.mirabeau.nl/)",
         "Leendert Ullersma <lullersma@mirabeau.nl> (http://www.mirabeau.nl/)",
@@ -34,6 +35,7 @@
         "gulp-jscs": "^1.6.0",
         "jscs-jsdoc": "^1.1.0",
         "gulp-sass": "^1.3.3",
+        "gulp-scss-lint": "^0.3.0",
         "gulp-sourcemaps": "^1.5.1",
         "gulp-swig": "^0.7.4",
         "gulp-uglify": "^1.1.0",

--- a/src/static/scss/all.scss
+++ b/src/static/scss/all.scss
@@ -1,8 +1,11 @@
-// Mixins
+@charset 'UTF-8';
+
+// Utils
+@import 'util/variables';
 @import 'util/position';
 
 // Vendor
-//@import 'vendor/normalize';
+@import 'vendor/normalize';
 
 // Common
 @import 'common/typography';

--- a/src/static/scss/common/_typography.scss
+++ b/src/static/scss/common/_typography.scss
@@ -1,4 +1,4 @@
 body {
-    font-family: Arial, sans-serif;
-    font-size: 18px;
+    font-family: $font-stack-arial;
+    font-size: $font-size-medium;
 }

--- a/src/static/scss/util/_variables.scss
+++ b/src/static/scss/util/_variables.scss
@@ -1,0 +1,8 @@
+// Colors
+$color-orange: #ffa500;
+
+
+// Fonts
+$font-size-medium: 18px;
+
+$font-stack-arial: Arial, Helvetica Neue, Helvetica, sans-serif;

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -7,6 +7,7 @@ var autoprefixer = require('gulp-autoprefixer');
 var filter       = require('gulp-filter');
 var browsersync  = require('browser-sync');
 var sassdoc      = require('sassdoc');
+var scsslint     = require('gulp-scss-lint');
 
 /**
  * Task: CSS Compile
@@ -43,4 +44,13 @@ module.exports.sassdoc = function() {
 
     gulp.src([config.paths.css.globStaticAll, config.paths.css.globComponents])
         .pipe(sassdoc(options));
+};
+
+
+/**
+ * Task: SCSS Lint
+ */
+module.exports.scsslint = function() {
+    gulp.src([config.paths.css.globStaticAll, config.paths.css.globComponents])
+        .pipe(scsslint());
 };


### PR DESCRIPTION
Added scss-lint gulp task to test scss code convention rules bases a .scss-lint.yml configuration file. The rules are mostly left as default (some are set more strict) and can be changed based on your project specific wishes and/or requirements.

The task can be executed by running `gulp sccs-lint` or if you want to run all the various tests at once via `gulp test`. 

Also updated the existing (example) .scss so it would pass the scss-lint test task.

Fixed project contributor's url typo in package.json