### PR TITLE
added viewport zoom fix for iOS 9

### DIFF
--- a/src/layout/default.html
+++ b/src/layout/default.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>Front-End Library</title>
     <meta name="format-detection" content="telephone=no" />
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="stylesheet" href="../static/css/all.css">
 
     {#- Shortest and fastest shim for ie-old html5 elements, add only the elements you need, or replace this with Modernizr -#}


### PR DESCRIPTION
I’ve added a fix for the standard viewport meta tag. The reason behind this, is explained at [Mattias Kihlström’s blog](http://kihlstrom.com/2015/shrink-to-fit-no-fixes-zoom-problem-in-ios-9/):

> In iOS 9 Apple has changed how Safari handles the viewport zoom at page load. Before, if you added `<meta name="viewport" content="widh=device-width, initial-scale=1">` to the head of your HTML document, you knew that the page would render at the width of the device (in CSS pixels) and be zoomed at 100%. Any elements wider than the device width or absolute positioned elements outside of the normal viewport would not affect the initial zoom.

> After the release of iOS 9 this is no longer the way it works. Instead of initially hiding things that does not fit the page horizontally, the browser will now automatically zoom out to accommodate everything.

I couldn’t explain this better than Mattias, so I decided to quote him :)