### PR TITLE
Refactored gulp tasks/subtasks setup

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,5 +1,3 @@
-'use strict';
-
 var pkg = require('./package.json');
 
 var base = {
@@ -8,72 +6,102 @@ var base = {
 };
 
 module.exports = {
-    autoprefixer: {
-        browsers: ['last 1 version', '> 5%']
-    },
 
-    /**
-     * Paths needed for Gulp
-     */
-    paths: {
-        clean: {
-            dirDest: base.dist
-        },
-        browsersync: {
-            baseDir:        base.dist
-        },
-        css: {
-            globStatic:     base.src + '/static/scss/**/!(_)*.scss',
-            globStaticAll:  base.src + '/static/scss/**/*.scss',
-            globFonts:      base.src + '/static/fonts/*',
-            dirDistFonts:   base.dist + '/static/fonts',
-            globComponents: base.src + '/components/**/*.scss',
-            dirDist:        base.dist + '/static/css',
-            sassdocsDist:   base.dist + '/docs/sassdoc'
-        },
-        html: {
-            globTemplates:  base.src + '/templates/**/*.html',
-            globLayout:     base.src + '/layout/*.html',
-            globComponents: base.src + '/components/**/*.html',
-            dirDist:        base.dist + '/templates'
-        },
-        img: {
-            globImages:     base.src + '/static/img/**/*.{svg,png,jpg,gif,webp}',
-            dirDist:        base.dist + '/static/img'
-        },
-        js: {
-            vendorFilter:   function(file) { return !/vendor/.test(file.path); },
-            globStatic:     base.src + '/static/js/**/*.js',
-            globVendor:     base.src + '/static/js/vendor/**/*.js',
-            globComponents: base.src + '/components/**/*.js',
-            dirDist:        base.dist + '/static/js'
-        },
-        githooks: {
-            globGithooks:   './tasks/githooks/*',
-            globDist:       './.git/hooks/*',
-            dirDist:        './.git/hooks'
+    browsersync: {
+        dist: {
+            base: base.dist
         }
     },
-    zip: {
-        paths: {
-            globDist:       base.dist + '/**/!(*.zip)',
-            dirDist:        base.dist
-        },
-        filename: pkg.name + '.zip'
+
+    clean: {
+        dist: {
+            base: base.dist
+        }
     },
 
-    /**
-     * Upload
-     * HOST, USER and PASSWORD constants should be defined within .env file
-     */
+    css: {
+        autoprefixer: {
+            browsers: ['last 1 version', '> 5%']
+        },
+        src: {
+            static: base.src + '/static/scss/**/!(_)*.scss',
+            staticAll: base.src + '/static/scss/**/*.scss',
+            fonts: base.src + '/static/fonts/*',
+            components: base.src + '/components/**/*.scss'
+        },
+        dist: {
+            base: base.dist + '/static/css',
+            fonts: base.dist + '/static/fonts',
+            sassdocs: base.dist + '/docs/sassdoc'
+        }
+    },
+
+    githooks: {
+        src: {
+            all: './tasks/githooks/*'
+        },
+        dist: {
+            base: './.git/hooks',
+            all: './.git/hooks/*'
+        }
+    },
+
+    html: {
+        src: {
+            templates: base.src + '/templates/**/*.html',
+            layout: base.src + '/layout/*.html',
+            components: base.src + '/components/**/*.html'
+        },
+        dist: {
+            base: base.dist + '/templates'
+        }
+    },
+
+    img: {
+        src: {
+            all: base.src + '/static/img/**/*.{svg,png,jpg,gif,webp}'
+        },
+        dist: {
+            base: base.dist + '/static/img'
+        }
+    },
+
+    js: {
+        src: {
+            all: base.src + '/static/js/**/*.js',
+            vendor: base.src + '/static/js/vendor/**/*.js',
+            components: base.src + '/components/**/*.js'
+        },
+        dist: {
+            base: base.dist + '/static/js'
+        },
+        vendorFilter: function(file) {
+            return !/vendor/.test(file.path);
+        }
+    },
+
     upload: {
-        globDist: base.dist + '/**',
-        targetPath: '/test',
-        targetBase: base.dist,
-        options: {
+        src: {
+            all: base.dist + '/**'
+        },
+        dist: {
+            target: '/test',
+            base: base.dist
+        },
+        options: { // Defined in .env file
             host: process.env.UPLOAD_HOST,
             user: process.env.UPLOAD_USER,
             password: process.env.UPLOAD_PASSWORD
+        }
+    },
+
+    zip: {
+        filename: pkg.name + '.zip',
+        src: {
+            all: base.dist + '/**/!(*.zip)'
+        },
+        dist: {
+            base: base.dist
         }
     }
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -4,53 +4,38 @@ var gulp = require('gulp');
 require('dotenv').load({ silent: true });
 
 // Load tasks
-var taskClean       = require('./tasks/clean');
-var taskBrowsersync = require('./tasks/browsersync');
-var tasksHTML       = require('./tasks/html');
-var tasksImages     = require('./tasks/img');
-var tasksCSS        = require('./tasks/css');
-var tasksJS         = require('./tasks/js');
-var tasksUpload     = require('./tasks/upload');
-var tasksGithooks   = require('./tasks/githooks');
-var tasksZip        = require('./tasks/zip');
+require('./tasks/clean');
+require('./tasks/browsersync');
+require('./tasks/html');
+require('./tasks/img');
+require('./tasks/css');
+require('./tasks/js');
+require('./tasks/upload');
+require('./tasks/githooks');
+require('./tasks/zip');
 
-// Clean dist/ folder
-gulp.task('clean', taskClean);
+gulp.task('dev', [
+    'clean',
+    'browsersync',
+    'html-watch',
+    'img-watch',
+    'css-watch',
+    'js-watch'
+]);
 
-// Serve files from dist/ folder
-gulp.task('browsersync', taskBrowsersync);
+gulp.task('dist', [
+    'clean',
+    'html-compile',
+    'img-optimize',
+    'css-compile',
+    'js-transpile'
+], function() { gulp.start(['zip']); });
 
-// Swig to HTML compiler
-gulp.task('html-compile', tasksHTML.compile);
-gulp.task('html-watch', ['html-compile'], tasksHTML.watch);
+gulp.task('test', [
+    'js-lint',
+    'css-lint'
+]);
 
-// Image optimizer
-gulp.task('img-optimize', tasksImages.optimize);
-gulp.task('img-watch', ['img-optimize'], tasksImages.watch);
-
-// Sass & Autoprefixer to CSS compiler
-gulp.task('css-compile', tasksCSS.compile);
-gulp.task('css-watch', ['css-compile'], tasksCSS.watch);
-gulp.task('css-sassdoc', tasksCSS.sassdoc);
-gulp.task('css-lint', []);
-
-// JavaScript transpiler
-gulp.task('js-transpile', tasksJS.transpile);
-gulp.task('js-lint', tasksJS.lint);
-gulp.task('js-watch', ['js-transpile'], tasksJS.watch);
-
-// Upload
-gulp.task('file-upload', ['dist'], tasksUpload.upload);
-
-// Zip
-gulp.task('zip', tasksZip.zip);
-
-// Githook tasks
-gulp.task('githooks-clean', tasksGithooks.clean);
-gulp.task('githooks', ['githooks-clean'], tasksGithooks.copy);
-
-// Group-tasks
-gulp.task('dev', ['clean', 'browsersync', 'html-watch', 'img-watch', 'css-watch', 'js-watch']);
-gulp.task('dist', ['clean', 'html-compile', 'img-optimize', 'css-compile', 'js-transpile'], function() { gulp.start(['zip']); });
-gulp.task('test', ['js-lint', 'css-lint']);
-gulp.task('upload', ['file-upload']);
+gulp.task('upload', [
+    'file-upload'
+]);

--- a/tasks/browsersync.js
+++ b/tasks/browsersync.js
@@ -1,16 +1,17 @@
 var config      = require('../config');
+var gulp        = require('gulp');
 var browsersync = require('browser-sync');
 
 /**
  * Task: BrowserSync HTTP server
  */
-module.exports = function() {
+gulp.task('browsersync', function() {
     browsersync({
         server: {
-            baseDir: config.paths.browsersync.baseDir
+            baseDir: config.browsersync.dist.base
         },
         /*ghostMode: false,
         notify: false,*/
         open: false
     });
-};
+});

--- a/tasks/clean.js
+++ b/tasks/clean.js
@@ -1,9 +1,10 @@
 var config = require('../config');
+var gulp   = require('gulp');
 var del    = require('del');
 
 /**
  * Task: Clean dist/ folder
  */
-module.exports = function() {
-    del.sync(config.paths.clean.dirDest);
-};
+gulp.task('clean', function() {
+    del.sync(config.clean.dist.base);
+});

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -4,69 +4,64 @@ var watch        = require('gulp-watch');
 var sass         = require('gulp-sass');
 var sourcemaps   = require('gulp-sourcemaps');
 var postcss      = require('gulp-postcss');
-var autoprefixer = require('autoprefixer');
 var filter       = require('gulp-filter');
-var browsersync  = require('browser-sync');
-var sassdoc      = require('sassdoc');
 var minifyCss    = require('gulp-minify-css');
+var autoprefixer = require('autoprefixer');
+var sassdoc      = require('sassdoc');
+var browsersync  = require('browser-sync');
+
+/**
+ * Sub-task: Compile Sass
+ */
+gulp.task('css-compile-sass', function() {
+    var postcssProcessors = [
+        autoprefixer({
+            browsers: config.css.autoprefixer.browsers
+        })
+    ];
+    return gulp.src(config.css.src.static)
+        .pipe(sourcemaps.init())
+        .pipe(sass().on('error', sass.logError))
+        .pipe(postcss(postcssProcessors))
+        .pipe(minifyCss())
+        .pipe(sourcemaps.write('.'))
+        .pipe(gulp.dest(config.css.dist.base))
+        .pipe(filter('**/*.css'))
+        .pipe(browsersync.reload({ stream: true }));
+});
+
+/**
+ * Sub-task: Copy fonts
+ */
+gulp.task('css-copy-fonts', function() {
+    return gulp.src(config.css.src.fonts)
+        .pipe(gulp.dest(config.css.dist.fonts))
+        .pipe(browsersync.reload({ stream: true }));
+});
 
 /**
  * Task: CSS Compile
  */
-module.exports.compile = function() {
-    var postcssProcessors = [
-        autoprefixer({
-            browsers: config.autoprefixer.browsers
-        })
-    ];
-
-    /**
-     * Task: Compile Sass
-     */
-    gulp.task('css-compile-sass', function() {
-        return gulp.src(config.paths.css.globStatic)
-            .pipe(sourcemaps.init())
-            .pipe(sass().on('error', sass.logError))
-            .pipe(postcss(postcssProcessors))
-            .pipe(minifyCss())
-            .pipe(sourcemaps.write('.'))
-            .pipe(gulp.dest(config.paths.css.dirDist))
-            .pipe(filter('**/*.css'))
-            .pipe(browsersync.reload({
-                stream: true
-            }));
-    });
-
-    /**
-     * Task: Copy fonts
-     */
-    gulp.task('css-copy-fonts', function() {
-        return gulp.src(config.paths.css.globFonts)
-            .pipe(gulp.dest(config.paths.css.dirDistFonts))
-            .pipe(browsersync.reload({ stream: true })); /* Todo: seems to cause a problem with browserSync (refresh) */
-    });
-
-    return gulp.start(['css-compile-sass', 'css-copy-fonts']);
-
-};
+gulp.task('css-compile', ['css-compile-sass', 'css-copy-fonts']);
 
 /**
  * Task: CSS Watch
  */
-module.exports.watch = function() {
-    watch([config.paths.css.globStaticAll, config.paths.css.globComponents], function() {
+gulp.task('css-watch', ['css-compile'], function() {
+    watch([config.css.src.staticAll, config.css.src.components], function() {
         gulp.start(['css-compile']);
     });
-};
+});
+
+/**
+ * Task: CSS Test
+ */
+gulp.task('css-lint', []);
 
 /**
  * Task: Generate Sassdoc documentation
  */
-module.exports.sassdoc = function() {
-    var options = {
-        dest: config.paths.css.sassdocsDist
-    };
-
-    gulp.src([config.paths.css.globStaticAll, config.paths.css.globComponents])
-        .pipe(sassdoc(options));
-};
+gulp.task('css-sassdoc', function() {
+    gulp.src([config.css.src.staticAll, config.css.src.components])
+        .pipe(sassdoc({ dest: config.css.dist.sassdocs }));
+});

--- a/tasks/githooks.js
+++ b/tasks/githooks.js
@@ -5,14 +5,14 @@ var del    = require('del');
 /**
  * Task: Copy Githooks
  */
-module.exports.copy = function() {
-    return gulp.src(config.paths.githooks.globGithooks)
-        .pipe(gulp.dest(config.paths.githooks.dirDist));
-};
+gulp.task('githooks', ['githooks-clean'], function() {
+    return gulp.src(config.githooks.src.all)
+        .pipe(gulp.dest(config.githooks.dist.base));
+});
 
 /**
  * Task: Clean Githooks dist folder
  */
-module.exports.clean = function() {
-    return del([config.paths.githooks.globDist]);
-};
+gulp.task('githooks-clean', function() {
+    return del([config.githooks.dist.all]);
+});

--- a/tasks/html.js
+++ b/tasks/html.js
@@ -7,19 +7,19 @@ var browsersync = require('browser-sync');
 /**
  * Task: HTML Compile
  */
-module.exports.compile = function() {
-    return gulp.src(config.paths.html.globTemplates)
+gulp.task('html-compile', function() {
+    return gulp.src(config.html.src.templates)
         .pipe(swig({ defaults: { cache: false } }))
-        .pipe(gulp.dest(config.paths.html.dirDist))
+        .pipe(gulp.dest(config.html.dist.base))
         .pipe(browsersync.reload({ stream: true }));
-};
+});
 
 /**
  * Task: HTML Watch
  */
-module.exports.watch = function() {
-    var paths = config.paths.html;
-    watch([paths.globTemplates, paths.globLayout, paths.globComponents], function() {
+gulp.task('html-watch', ['html-compile'], function() {
+    var paths = config.html.src;
+    watch([paths.templates, paths.layout, paths.components], function() {
         gulp.start(['html-compile']);
     });
-};
+});

--- a/tasks/img.js
+++ b/tasks/img.js
@@ -7,18 +7,18 @@ var imagemin = require('gulp-imagemin');
 /**
  * Task: Image optimizer
  */
-module.exports.optimize = function() {
-    return gulp.src(config.paths.img.globImages)
-        .pipe(changed(config.paths.img.dirDist))
+gulp.task('img-optimize', function() {
+    return gulp.src(config.img.src.all)
+        .pipe(changed(config.img.dist.base))
         .pipe(imagemin())
-        .pipe(gulp.dest(config.paths.img.dirDist));
-};
+        .pipe(gulp.dest(config.img.dist.base));
+});
 
 /**
  * Task: Image Watch
  */
-module.exports.watch = function() {
-    watch([config.paths.img.globImages], function() {
+gulp.task('img-watch', ['img-optimize'], function() {
+    watch([config.img.src.all], function() {
         gulp.start(['img-optimize']);
     });
-};
+});

--- a/tasks/js.js
+++ b/tasks/js.js
@@ -12,32 +12,33 @@ var browsersync = require('browser-sync');
 /**
  * Task: JS Transpile
  */
-module.exports.transpile = function() {
-    return gulp.src([config.paths.js.globStatic, config.paths.js.globComponents])
-        .pipe(changed(config.paths.js.dirDist))
+gulp.task('js-transpile', function() {
+    return gulp.src([config.js.src.all, config.js.src.components])
+        .pipe(changed(config.js.dist.base))
         .pipe(sourcemaps.init())
-        .pipe(gulpif(config.paths.js.vendorFilter, babel()))
+        .pipe(gulpif(config.js.vendorFilter, babel()))
         .pipe(uglify())
         .pipe(sourcemaps.write('.'))
-        .pipe(gulp.dest(config.paths.js.dirDist))
+        .pipe(gulp.dest(config.js.dist.base))
         .pipe(browsersync.reload({ stream: true }));
-};
+});
 
 /**
  * Task: JS Watch
  */
-module.exports.watch = function() {
-    watch([config.paths.js.globStatic, config.paths.js.globComponents], function() {
+gulp.task('js-watch', ['js-transpile'], function() {
+    watch([config.js.src.all, config.js.src.components], function() {
         gulp.start(['js-transpile']);
     });
-};
+});
 
 /**
  * Task: JS Test
  */
-module.exports.lint = function() {
-    return gulp.src([config.paths.js.globStatic, config.paths.js.globComponents, '!' + config.paths.js.globVendor])
+gulp.task('js-lint', function() {
+    var src = config.js.src;
+    return gulp.src([src.all, src.components, '!' + src.vendor])
         .pipe(eslint())
         .pipe(eslint.format())
         .pipe(eslint.failAfterError());
-};
+});

--- a/tasks/upload.js
+++ b/tasks/upload.js
@@ -1,15 +1,14 @@
+var config = require('../config');
 var gulp   = require('gulp');
 var gutil  = require('gulp-util');
 var ftp    = require('vinyl-ftp');
-var config = require('../config');
 
 /**
  * Task: Upload via FTP
  */
-module.exports.upload = function() {
+gulp.task('file-upload', ['dist'], function() {
     var opts = config.upload.options;
     opts.log = gutil.log;
-
-    return gulp.src([config.upload.globDist], { base: config.upload.targetBase, buffer: false })
-        .pipe(ftp.create(opts).dest(config.upload.targetPath));
-};
+    return gulp.src([config.upload.src.all], { base: config.upload.dist.base, buffer: false })
+        .pipe(ftp.create(opts).dest(config.upload.dist.target));
+});

--- a/tasks/zip.js
+++ b/tasks/zip.js
@@ -5,9 +5,8 @@ var zip    = require("gulp-zip");
 /**
  * Task: Add content to zip archive
  */
-module.exports.zip = function() {
-
-    return gulp.src([config.zip.paths.globDist])
+gulp.task('zip', function() {
+    return gulp.src([config.zip.src.all])
         .pipe(zip(config.zip.filename))
-        .pipe(gulp.dest(config.zip.paths.dirDist));
-};
+        .pipe(gulp.dest(config.zip.dist.base));
+});


### PR DESCRIPTION
It turns out the current setup of defining gulp tasks in a `tasks/` subfolder to keep it all manageable, can be achieved with a gulpfile.js that has half the code, and it's more readable. An [example can be found here](https://gist.github.com/branneman/c7c52fe54ac880f08a9f).

The principal change is moving away from `module.exports = function() {...}` and just let the subtask files call `gulp.task()` directly. This means that there's only group-tasks in the `gulpfile.js` from now on, nice and clean.