### PR TITLE
Added Sassdoc to the documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,4 @@ Thumbs.db
 
 
 # Other
-docs/sassdoc
 .env

--- a/config.js
+++ b/config.js
@@ -32,8 +32,7 @@ module.exports = {
         },
         dist: {
             base: base.dist + '/static/css',
-            fonts: base.dist + '/static/fonts',
-            sassdocs: base.dist + '/docs/sassdoc'
+            fonts: base.dist + '/static/fonts'
         }
     },
 
@@ -47,7 +46,8 @@ module.exports = {
         dist: {
             base: base.dist,
             index: base.dist + '/index.html',
-            static: base.dist + '/docs/static/'
+            static: base.dist + '/docs/static/',
+            sassdocs: base.dist + '/docs/sassdoc'
         }
     },
 

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -7,7 +7,6 @@ var postcss      = require('gulp-postcss');
 var filter       = require('gulp-filter');
 var minifyCss    = require('gulp-minify-css');
 var autoprefixer = require('autoprefixer');
-var sassdoc      = require('sassdoc');
 var browsersync  = require('browser-sync');
 
 /**
@@ -57,11 +56,3 @@ gulp.task('css-watch', ['css-compile'], function() {
  * Task: CSS Test
  */
 gulp.task('css-lint', []);
-
-/**
- * Task: Generate Sassdoc documentation
- */
-gulp.task('css-sassdoc', function() {
-    gulp.src([config.css.src.staticAll, config.css.src.components])
-        .pipe(sassdoc({ dest: config.css.dist.sassdocs }));
-});

--- a/tasks/docs.js
+++ b/tasks/docs.js
@@ -1,10 +1,11 @@
-var config = require('../config');
-var gulp   = require('gulp');
-var swig   = require('gulp-swig');
-var watch  = require('gulp-watch');
-var glob   = require('glob');
-var path   = require('path');
-var moment = require('moment-timezone');
+var config  = require('../config');
+var gulp    = require('gulp');
+var swig    = require('gulp-swig');
+var watch   = require('gulp-watch');
+var glob    = require('glob');
+var path    = require('path');
+var moment  = require('moment-timezone');
+var sassdoc = require('sassdoc');
 
 /**
  * Sub-task: Docs copy statics
@@ -39,7 +40,7 @@ gulp.task('docs-render-index', function() {
 /**
  * Task: Docs Compile
  */
-gulp.task('docs-compile', ['docs-copy-statics', 'docs-render-index']);
+gulp.task('docs-compile', ['docs-copy-statics', 'docs-render-index', 'docs-sassdoc']);
 
 /**
  * Task: Docs Watch
@@ -54,4 +55,12 @@ gulp.task('docs-watch', ['docs-compile'], function() {
     watch(watching, function() {
         gulp.start(['docs-compile']);
     });
+});
+
+/**
+ * Task: Docs sassdoc
+ */
+gulp.task('docs-sassdoc', function() {
+    gulp.src([config.css.src.staticAll, config.css.src.components])
+        .pipe(sassdoc({ dest: config.docs.dist.sassdocs }))
 });

--- a/tasks/docs/index.html
+++ b/tasks/docs/index.html
@@ -22,6 +22,9 @@
         {%- endfor %}
         </ol>
 
+        <h2>Sassdoc</h2>
+        <p><a href="docs/sassdoc/index.html">Sassdoc</a></p>
+
     </div>
 
 </body>


### PR DESCRIPTION
This will add documentation to the bootstrap (gulp task ```gulp doc```).
The ```css-sassdoc``` has been moved to ```gulp doc``` because sassdoc is documentation.
It also the requested outcome/solution for #24 