### PR TITLE
Changed order of common scss files

### DIFF
--- a/src/static/scss/all.scss
+++ b/src/static/scss/all.scss
@@ -5,8 +5,8 @@
 //@import 'vendor/normalize';
 
 // Common
-@import 'common/typography';
 @import 'common/colors';
+@import 'common/typography';
 @import 'common/grid';
 
 // Modules


### PR DESCRIPTION
I placed the import of _colors.scss above _typography.scss. This is because I encountered a simple “undefined variable” error in SASS. I think most people would like to use colors as well in their typography rules, so that’s why I switched them.