### PR TITLE
Remove bootstrap css from component preview render

### DIFF
--- a/tasks/docs/layout/preview.html
+++ b/tasks/docs/layout/preview.html
@@ -5,7 +5,6 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Front-End Library</title>
-    <link rel="stylesheet" href="/docs/static/css/bootstrap.css">
     <link rel="stylesheet" href="/static/css/all.css">
     <script>
         (function(d){


### PR DESCRIPTION
Fixes a bug on the component preview page. Bootstrap was included when the component preview was rendered, causing the bootstrap css to conflict with the component's css.