### PR TITLE
Unused path .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 **/vendor/**
 **/polyfill/**
-**/shim/**
 **/*.min.js


### PR DESCRIPTION
All `shim` files should be stored in the `polyfill` folder