### PR TITLE
Updated (S)CSS linter Stylelint configuration

### DIFF
--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -13,7 +13,7 @@ rules:
         - first-nested
       ignore:
         - after-comment
-        - all-nested
+        - inside-block
   block-closing-brace-newline-after:
     - always
     -

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.0.4",
     "gulp-sourcemaps": "^1.5.2",
-    "gulp-stylelint": "^3.8.0",
+    "gulp-stylelint": "^3.9.0",
     "gulp-tap": "^0.1.3",
     "gulp-transform": "^1.0.8",
     "gulp-uglify": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.0.4",
     "gulp-sourcemaps": "^1.5.2",
-    "gulp-stylelint": "^3.7.0",
+    "gulp-stylelint": "^3.8.0",
     "gulp-tap": "^0.1.3",
     "gulp-transform": "^1.0.8",
     "gulp-uglify": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "read-yaml": "^1.0.0",
     "run-sequence": "^1.1.5",
     "sassdoc": "2.1.20",
-    "stylelint-config-standard": "^15.0.1",
+    "stylelint-config-standard": "^16.0.0",
     "stylelint-declaration-strict-value": "^1.0.3",
     "stylelint-scss": "^1.4.1",
     "through2": "^2.0.1",


### PR DESCRIPTION
As of Stylelint 7.8.0, three of our used rules are deprecated. As of Stylelint 8.0 they will be removed. Therefore I’ve updated our dependency of stylelint-config-standard to version 16 and changed one rule of our own configuration