### PR TITLE
Remove sassdoc

### DIFF
--- a/config.js
+++ b/config.js
@@ -58,7 +58,6 @@ module.exports = {
             base: base.dist,
             index: base.dist + '/index.html',
             static: base.dist + '/docs/static/',
-            sassdocs: base.dist + '/docs/sassdoc',
             components: base.dist + '/docs/components/'
         }
     },

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "moment-timezone": "^0.5.3",
     "require-globify": "^1.4.1",
     "run-sequence": "^1.1.5",
-    "sassdoc": "2.1.20",
     "stylelint-config-standard": "^16.0.0",
     "stylelint-declaration-strict-value": "^1.0.3",
     "stylelint-scss": "^1.4.1",

--- a/src/static/scss/util/_position.scss
+++ b/src/static/scss/util/_position.scss
@@ -1,11 +1,10 @@
-/// @author Bran van der Meer
-///
-/// Mixin to provide short-hand positioning syntax
-/// @param {Position} $position [relative] - The position value
-/// @param {Map} $coordinates [0 0 0 0] - Position offset top, right, bottom and left
-/// @link https://gist.github.com/branneman/9248961
-/// @example scss - Position mixin
-///     @include position(absolute, 0 false 0 20rem);
+// @author Bran van der Meer
+//
+// Mixin to provide short-hand positioning syntax
+// @param {Position} $position [relative] - The position value
+// @param {Map} $coordinates [0 0 0 0] - Position offset top, right, bottom and left
+// @link https://gist.github.com/branneman/9248961
+// @example position(absolute, 0 false 0 20rem);
 
 @mixin position ($position: relative, $coordinates: 0 0 0 0) {
     @if type-of($position) == list {

--- a/tasks/docs.js
+++ b/tasks/docs.js
@@ -4,7 +4,6 @@ import render from 'gulp-nunjucks-render';
 import watch from 'gulp-watch';
 import moment from 'moment-timezone';
 import runSequence from 'run-sequence';
-import sassdoc from 'sassdoc';
 import transform from 'gulp-transform';
 import ext from 'gulp-ext-replace';
 import gulpif from 'gulp-if';
@@ -70,14 +69,6 @@ gulp.task('docs-render-component-demos', () =>
 );
 
 /**
- * Task: Docs sassdoc
- */
-gulp.task('docs-sassdoc', () =>
-    gulp.src([config.css.src.staticAll, config.css.src.components])
-        .pipe(sassdoc({ dest: config.docs.dist.sassdocs }))
-);
-
-/**
  * Task: Docs Compile
  */
 gulp.task('docs', cb =>
@@ -85,8 +76,7 @@ gulp.task('docs', cb =>
         'docs-copy-statics',
         'docs-render-index',
         'docs-render-components',
-        'docs-render-component-demos',
-        'docs-sassdoc'
+        'docs-render-component-demos'
     ], cb)
 );
 

--- a/tasks/docs/index.html
+++ b/tasks/docs/index.html
@@ -36,9 +36,6 @@
             {% endfor %}
         </ul>
 
-        <h2>Sassdoc</h2>
-        <p><a href="docs/sassdoc/index.html">Sassdoc</a></p>
-
 </div>
 
 {%- endblock %}


### PR DESCRIPTION
Resolve #50.

A deprecated warning of Swig when installing the bootstrap (which was required by a dependency of sassdoc) is also gone.