### PR TITLE
Update gulp-mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "gulp-filter": "^4.0.0",
     "gulp-if": "^2.0.0",
     "gulp-imagemin": "^3.0.1",
-    "gulp-mocha": "^2.2.0",
+    "gulp-mocha": "^4.3.0",
     "gulp-nunjucks-render": "^2.0.0",
     "gulp-postcss": "^6.4.0",
     "gulp-rename": "^1.2.2",

--- a/src/components/nav/Nav.js
+++ b/src/components/nav/Nav.js
@@ -22,7 +22,7 @@ class Nav {
      * Construct module
      */
     load() {
-        this._element.innerHTML += [2, 4, 6, 8, 20].map(v => v + 1);
+        this._element.innerHTML += [2, 4, 6, 8, 10].map(v => v + 1);
     }
 
     /**

--- a/tasks/js.js
+++ b/tasks/js.js
@@ -46,10 +46,12 @@ gulp.task('js-lint', () => {
  * Task: JS unit tests
  */
 gulp.task('js-test', () => {
-    require('babel-register');
-
     return gulp.src([config.src.tests])
-        .pipe(mocha());
+        .pipe(mocha({
+            compilers: [
+                'js:babel-register'
+            ]
+        }));
 });
 
 


### PR DESCRIPTION
This updates gulp-mocha to the most recent version. 

In this version, the current way of requiring babel-register did not work anymore. The fix is based on [this answer](http://stackoverflow.com/questions/28858957/gulp-mocha-how-to-pass-the-compilers-flag/33510155#33510155).

A deprecated warning of jade and to-iso-string when installing the bootstrap (which was required by a dependency of the old gulp-mocha) is also gone.