### PR TITLE
Upgrade to Autoprefixer 7.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "readmeFilename": "readme.md",
   "license": "BSD-3-Clause",
   "devDependencies": {
-    "autoprefixer": "^6.7.7",
+    "autoprefixer": "^7.1.1",
     "babel-core": "^6.24.0",
     "babel-eslint": "^7.2.1",
     "babel-plugin-external-helpers": "^6.8.0",
@@ -52,7 +52,7 @@
     "gulp-imagemin": "^3.0.1",
     "gulp-mocha": "^4.3.0",
     "gulp-nunjucks-render": "^2.0.0",
-    "gulp-postcss": "^6.4.0",
+    "gulp-postcss": "^7.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.0.4",
     "gulp-sourcemaps": "^1.5.2",


### PR DESCRIPTION
For the second time, I stumbled upon [https://evilmartians.com/chronicles/autoprefixer-7-browserslist-2-released](https://evilmartians.com/chronicles/autoprefixer-7-browserslist-2-released).

The following reasons are why Autoprefixer has been updated:
- Reducing size of node_modules with around 6MB
- Several issues concerning Grid Layout
- Updated PostCSS (better performance)
- Switch to Browserslist 2

As https://github.com/postcss/autoprefixer/blob/master/CHANGELOG.md mentions “Use PostCSS 6.0” at release 7.0, I’ve updated PostCSS as well by updating gulp-postcss to version 7.0.0

Browserslist 2 brings us better support for other browsers next to the “main browsers” when it comes to using `last n versions`