### PR TITLE
Moved to default support config for Autoprefixer

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,3 @@
+> 1%
+last 2 versions
+Firefox ESR

--- a/config.js
+++ b/config.js
@@ -27,9 +27,6 @@ module.exports = {
     },
 
     css: {
-        autoprefixer: {
-            browsers: ['> 1%', 'last 2 versions']
-        },
         src: {
             static: `${base.src}/static/scss/**/!(_)*.scss`,
             staticAll: `${base.src}/static/scss/**/*.scss`,

--- a/config.js
+++ b/config.js
@@ -28,7 +28,7 @@ module.exports = {
 
     css: {
         autoprefixer: {
-            browsers: ['last 1 version', '> 5%']
+            browsers: ['> 1%', 'last 2 versions']
         },
         src: {
             static: `${base.src}/static/scss/**/!(_)*.scss`,

--- a/tasks/css.js
+++ b/tasks/css.js
@@ -15,9 +15,7 @@ import stylelint from 'gulp-stylelint';
  */
 gulp.task('css', () => {
     const postcssProcessors = [
-        autoprefixer({
-            browsers: config.autoprefixer.browsers
-        })
+        autoprefixer()
     ];
 
     return gulp.src(config.src.static)


### PR DESCRIPTION
We have a support config for Browserslist (used by Autoprefixer) that’s opinionated. I’m proposing to change it to default, unless we have a very good reason for it. Each developer should change the default setting to its own needs.