### PR TITLE
Add lock files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ dist/*
 .cache
 
 
+# Lock
+package-lock.json
+yarn.lock
+
+
 # Operating system
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
For our local development environment these lock files are not needed. 