### PR TITLE
Githooks fix

### DIFF
--- a/tasks/githooks.js
+++ b/tasks/githooks.js
@@ -7,7 +7,7 @@ import gulp from 'gulp';
  */
 gulp.task('githooks', ['githooks-clean'], () => {
     return gulp.src(config.src.all)
-        .pipe(gulp.dest(config.dist.base));
+        .pipe(gulp.dest(config.dist.base, { mode: '0500' }));
 });
 
 /**


### PR DESCRIPTION
A small tweak to make sure that githooks can be executed on macOS/Linux after being copied.

Should work fine on windows machines but needs to be tested also.